### PR TITLE
Categorical sample

### DIFF
--- a/io.lisp
+++ b/io.lisp
@@ -91,18 +91,16 @@
   (with-input-from-string (s str)
     (read-all-from-stream s)))
 
-(declaim (inline write-to-file))
-(defun write-to-file (str filename)
+(defmacro write-to-file (str filename &rest openargs)
   "Writes a string to a file."
   (declare (optimize (speed 1)))
-  (declare (type simple-string str))
-  (with-open-file (fh filename :direction :output)
-    (format fh str)))
+  `(with-open-file (fh ,filename :direction :output ,@openargs)
+    (format fh ,str)))
 
-(defun write-list-to-file (lst filename &optional (sep "~%"))
+(defmacro write-list-to-file (lst filename &optional (sep "~%") &rest openargs)
   "Writes a list to a file.
   Depends on write-to-file."
-  (write-to-file (list-to-string lst sep) filename))
+  `(write-to-file (list-to-string ,lst ,sep) ,filename ,@openargs))
 
 (defun princln (x)
   "CL version of 'println' in Java.

--- a/package.lisp
+++ b/package.lisp
@@ -157,5 +157,6 @@
     ;; random.lisp
     set-seed
     uniform-sample
+    categorical-sample
     ))
 

--- a/random.lisp
+++ b/random.lisp
@@ -23,11 +23,10 @@
    n : the number of samples desired"
   ;; NB: d0 ending ensures double floats for precision.
   (let ((sample-vals 
-          (sort (loop for x from 0 upto n collect (random 1.0d0))
+          (sort (loop for x from 0 below n collect (random 1.0d0))
                 #'<))
         (curval 0.0d0)
         samples)
-    (format t "sample-vals: ~s~%" sample-vals)
     (loop for (c . w) in cats
           do (incf curval w)
           do (loop while (and sample-vals

--- a/random.lisp
+++ b/random.lisp
@@ -11,3 +11,28 @@
   (loop for i from 1 to n
         collect (nth (random (length lst)) lst)))
 
+; TODO: write a more efficient version https://github.com/enewe101/categorical
+(defun categorical-sample (cats &optional (n 1))
+  "Samples from a categorical distribution.
+   
+   NB: The results will be sorted in the reverse order of cats.
+
+   Arguments
+   ---------
+   cats : a association list from categories to weights to sample from
+   n : the number of samples desired"
+  ;; NB: d0 ending ensures double floats for precision.
+  (let ((sample-vals 
+          (sort (loop for x from 0 upto n collect (random 1.0d0))
+                #'<))
+        (curval 0.0d0)
+        samples)
+    (format t "sample-vals: ~s~%" sample-vals)
+    (loop for (c . w) in cats
+          do (incf curval w)
+          do (loop while (and sample-vals
+                              (< (car sample-vals) curval))
+                   do (push c samples)
+                   do (setf sample-vals (cdr sample-vals))))
+    samples))
+

--- a/string.lisp
+++ b/string.lisp
@@ -56,6 +56,8 @@
 
 ;; Converts a list to a string with a given delimiter between elements.
 ;; Elements are represented with the usual string representation.
+(declaim (ftype (function (list string &optional boolean) string)
+                list-to-string))
 (defun list-to-string (lst delim &optional (remove-newlines nil))
   (reduce
     #'(lambda (x y)


### PR DESCRIPTION
Add a function `categorical-sample` that samples from a categorical distribution. Highly-inefficient, but works for non-computationally intensive purposes.

Also, an unrelated improvement to `write-to-file` and `write-list-to-file` which are written as macros and can take file opening flags.